### PR TITLE
deps: update handlebars and hbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "express": "^4.15.0",
     "express-prettify": "^0.0.7",
     "get-logger": "^1.0.0",
-    "handlebars": "^4.0.6",
-    "hbs": "^4.0.1",
+    "handlebars": "^4.0.13",
+    "hbs": "^4.0.2",
     "jquery": "^3.2.1",
     "lodash": "^4.17.4",
     "prismjs": "^1.6.0"


### PR DESCRIPTION
See https://www.npmjs.com/advisories/755/versions.

This came up because `admin` is a dev-dependency of instana/nodejs-sensor. Please `npm publish` after merging. :-)